### PR TITLE
handling empty lines in get_columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ Options:
   -m, --model-path PATH       The path to models
   -t, --transforms-path PATH  Path to a .yml file containing transformations
   -o, --output-path PATH      Path to write transformed models to
-  --drop-metadata BOOLEAN     The drop metadata flag
-  --case-sensitive BOOLEAN    The case sensitive flag
+  --drop-metadata BOOLEAN     (default=True) optionally drop source columns prefixed with "_" if that designates metadata columns not needed in target
+  --case-sensitive BOOLEAN    (default=False) treat column names as case-sensitive - otherwise force all to lower
   --help                      Show this message and exit.
 ```
 
@@ -96,6 +96,7 @@ Here are some of the limitations of the current release. If you want to contribu
 
 * Transforms only works with model generated with the code-gen package. 
 * You cannot transform a model that has already been transformed
+*     - transformation logic assumes base model contains just a list of column names with no aliases or SQL logic added
 * You cannot use wild card in fields selection for transforms (e.g. `*_id`)
-* No tests yet
+* Limited test coverage
 * No error handling yet

--- a/tests/test_data/expected/transformed__drop_metadata.sql
+++ b/tests/test_data/expected/transformed__drop_metadata.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('GOOGLE_ADS', 'ACCOUNTS') }}
+
+),
+
+renamed as (
+
+    select
+        canmanageclients,
+        currencycode,
+        CAST(customerid as varchar) as customer_id,
+        date_trunc('day',datetimezone) as date_time_zone,
+        CAST(NAME as varchar) as col_name,
+        testaccount
+
+    from source
+
+)
+
+select * from renamed

--- a/tests/test_data/expected/transformed__keep_metadata.sql
+++ b/tests/test_data/expected/transformed__keep_metadata.sql
@@ -1,0 +1,27 @@
+with source as (
+
+    select * from {{ source('GOOGLE_ADS', 'ACCOUNTS') }}
+
+),
+
+renamed as (
+
+    select
+        canmanageclients,
+        currencycode,
+        CAST(customerid as varchar) as customer_id,
+        date_trunc('day',datetimezone) as date_time_zone,
+        CAST(NAME as varchar) as col_name,
+        testaccount,
+        _sdc_batched_at,
+        _sdc_customer_id,
+        _sdc_extracted_at,
+        _sdc_received_at,
+        _sdc_sequence as _sdc_seq,
+        _sdc_table_version
+
+    from source
+
+)
+
+select * from renamed

--- a/tests/test_data/out/transformed__drop_metadata.sql
+++ b/tests/test_data/out/transformed__drop_metadata.sql
@@ -1,0 +1,21 @@
+with source as (
+
+    select * from {{ source('GOOGLE_ADS', 'ACCOUNTS') }}
+
+),
+
+renamed as (
+
+    select
+        canmanageclients,
+        currencycode,
+        CAST(customerid as varchar) as customer_id,
+        date_trunc('day',datetimezone) as date_time_zone,
+        CAST(NAME as varchar) as col_name,
+        testaccount
+
+    from source
+
+)
+
+select * from renamed

--- a/tests/test_data/test_transform.yml
+++ b/tests/test_data/test_transform.yml
@@ -9,3 +9,14 @@ DATE_START:
   name: START_AT
 DATE_STOP:
   name: STOP_AT
+NAME:
+  name: col_name
+  sql: CAST(NAME as varchar)
+customerid:
+  name: customer_id
+  sql: CAST(customerid as varchar)
+datetimezone:
+  name: date_time_zone
+  sql: date_trunc('day',datetimezone)
+_sdc_sequence:
+  name: _sdc_seq

--- a/tests/test_process_base_models.py
+++ b/tests/test_process_base_models.py
@@ -1,13 +1,16 @@
 import os
-from dbt_generator.process_base_models import ProcessBaseQuery
 
+import dbt_generator.process_base_models as dbt_gen
+import filecmp
 
-COLUMNS = ['canmanageclients', 'currencycode', 'customerid', 'datetimezone', 'name', 'testaccount', '_sdc_batched_at',
-           '_sdc_customer_id', '_sdc_extracted_at', '_sdc_received_at', '_sdc_sequence', '_sdc_table_version']
+COLUMNS = ['canmanageclients', 'currencycode', 'customerid', 'datetimezone', 'name', 'testaccount', 
+          '_sdc_batched_at','_sdc_customer_id', '_sdc_extracted_at', '_sdc_received_at', 
+          '_sdc_sequence', '_sdc_table_version'
+          ]
 
 
 def test_ProcessBaseQuery():
-    pbq = ProcessBaseQuery(
+    pbq = dbt_gen.ProcessBaseQuery(
         sql_file=os.path.join(os.path.dirname(__file__),
                               'test_data', 'test_sql_file.sql'),
         transforms_file=os.path.join(os.path.dirname(
@@ -15,3 +18,37 @@ def test_ProcessBaseQuery():
     )
 
     assert pbq.columns == COLUMNS
+
+
+def test_transform__drop_metadata():
+    input_file = os.path.join(os.path.dirname(__file__),'test_data', 'test_sql_file.sql')
+    trfm_file = os.path.join(os.path.dirname(__file__), 'test_data', 'test_transform.yml')
+    output_file = os.path.join(os.path.dirname(__file__),'test_data/out', 'transformed__drop_metadata.sql')
+    expected_file = os.path.join(os.path.dirname(__file__),'test_data/expected', 'transformed__drop_metadata.sql')
+
+    pbq = dbt_gen.ProcessBaseQuery(
+        sql_file= input_file,
+        transforms_file= trfm_file,
+        drop_metadata=True
+    )
+
+    pbq.write_file(output_file)
+
+    assert filecmp.cmp(expected_file, output_file, shallow=False)
+
+
+def test_transform__keep_metadata():
+    input_file = os.path.join(os.path.dirname(__file__),'test_data', 'test_sql_file.sql')
+    trfm_file = os.path.join(os.path.dirname(__file__), 'test_data', 'test_transform.yml')
+    output_file = os.path.join(os.path.dirname(__file__),'test_data/out', 'transformed__keep_metadata.sql')
+    expected_file = os.path.join(os.path.dirname(__file__),'test_data/expected', 'transformed__keep_metadata.sql')
+
+    pbq = dbt_gen.ProcessBaseQuery(
+        sql_file= input_file,
+        transforms_file= trfm_file,
+        drop_metadata=False
+    )
+
+    pbq.write_file(output_file)
+
+    assert filecmp.cmp(expected_file, output_file, shallow=False)


### PR DESCRIPTION
assumptions about line index caused failure in some testing, so attempting to make that logic simpler here.
line index start and stop for column list ignores empty lines.  and logic is now removing empty lines in get_columns and then adding them back in process_sql & write_file